### PR TITLE
Port lua-jwt to luaossl, since LuaCrypto is deprecated

### DIFF
--- a/luajwtjitsi-1.3-7.rockspec
+++ b/luajwtjitsi-1.3-7.rockspec
@@ -1,5 +1,5 @@
 package = "luajwtjitsi"
-version = "1.3-6"
+version = "1.3-7"
 
 source = {
 	url = "git://github.com/paweldomas/luajwt/",

--- a/luajwtjitsi-1.3-7.rockspec
+++ b/luajwtjitsi-1.3-7.rockspec
@@ -3,7 +3,7 @@ version = "1.3-6"
 
 source = {
 	url = "git://github.com/paweldomas/luajwt/",
-	tag = "v1.6"
+	tag = "v1.7"
 }
 
 description = {
@@ -15,7 +15,7 @@ description = {
 
 dependencies = {
 	"lua >= 5.1",
-	"luacrypto >= 0.3.2-1",
+	"luaossl >= 20161214-0",
 	"lua-cjson >= 2.1.0",
 	"lbase64 >= 20120807-3"
 }

--- a/luajwtjitsi-1.8.rockspec
+++ b/luajwtjitsi-1.8.rockspec
@@ -1,15 +1,15 @@
 package = "luajwtjitsi"
-version = "1.3-7"
+version = "1.8"
 
 source = {
-	url = "git://github.com/paweldomas/luajwt/",
-	tag = "v1.7"
+	url = "git://github.com/maxdebayser/luajwt/",
+	tag = "v1.8"
 }
 
 description = {
 	summary = "JSON Web Tokens for Lua",
 	detailed = "Very fast and compatible with pyjwt, php-jwt, ruby-jwt, node-jwt-simple and others",
-	homepage = "https://github.com/paweldomas/luajwt/",
+	homepage = "https://github.com/maxdebayser/luajwt/",
 	license = "MIT <http://opensource.org/licenses/MIT>"
 }
 

--- a/luajwtjitsi.lua
+++ b/luajwtjitsi.lua
@@ -191,7 +191,7 @@ function M.decode(data, key, verify)
 
 	if verify then
 
-		if not header.typ or header.typ ~= "JWT" then
+		if not header.typ or (header.typ ~= "JOSE" and header.typ ~= "JWT") then
 			return nil, "Invalid typ"
 		end
 


### PR DESCRIPTION
According to the author of LuaCrypto, this library is deprecated and luaossl should be used instead. So this commit ports lua-jwt to luaossl. Very few changes were necessary. The most verbose part of this commit are the alternative implementations of tohex, each optimized for a specific lua interpreter. This is to keep the validations fast, to avoid to much overhead on small HTTP requests.