### PR TITLE
Ported code from luacrypto to luaossl

### DIFF
--- a/luajwtjitsi-1.3-7.rockspec
+++ b/luajwtjitsi-1.3-7.rockspec
@@ -15,7 +15,7 @@ description = {
 
 dependencies = {
 	"lua >= 5.1",
-	"luacrypto >= 0.3.2-1",
+	"luaossl >= 20190731-0",
 	"lua-cjson >= 2.1.0",
 	"lbase64 >= 20120807-3"
 }


### PR DESCRIPTION
Hello,
The current version of luajwt uses old luacrypto library, which does not compile with Openssl 1.1. This makes it difficult to install in an updated Linux system such as Debian 10.

Following the advice from https://github.com/starius/luacrypto/ (see the README "this project is deprecated, use luaossl") I ported this library to luaossl.